### PR TITLE
Release Version 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![npm version](https://badge.fury.io/js/homebridge-magic-occupancy.svg)](https://badge.fury.io/js/homebridge-magic-occupancy)
 [![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
 
-**DO NOT UPDATE TO 3.0 BETA UNLESS YOU ARE OKAY WITH ALL YOUR PLUGIN CONFIGS BEING RESET TO DEFAULTS WHICH WILL LOSE ANY AUTOMATIONS YOU SET UP IN THE HOME APP**
+**DO NOT UPDATE TO v3 UNLESS YOU ARE OKAY WITH ALL YOUR PLUGIN CONFIGS BEING RESET TO DEFAULTS WHICH WILL LOSE ANY AUTOMATIONS YOU SET UP IN THE HOME APP. v3 IS A SIGNIFICANT REWRITE AND OFFERS DIFFERENT OPTIONS THAN v2 WHICH ARE VERY POWERFUL BUT REQUIRE A MANUAL UPGRADE**
 
 ## How to install
 
@@ -16,14 +16,14 @@
           "accessory": "MagicOccupancy",
           "name": "Hallway Occupancy",
           "stayOccupiedDelay": 60,
-          "maxOccupationSeconds": 86400,
-          "statefulSwitchesCount": 1,
-          "triggerSwitchesCount": 1,
-          "motionSwitchesCount": 1,
-          "statefulStayOnSwitchesCount": 1,
-          "triggerStayOnSwitchesCount": 1,
-          "motionStayOnSwitchesCount": 1,
-          "ignoreStatefulIfTurnedOnByTrigger": true,
+          "maxOccupationTimeout": 86400,
+          "persistBetweenReboots": true,
+          "startOnReboot": false,
+          "lightSwitchesNames": "Light Switch 1, Light Switch 2",
+          "statefulSwitchesNames": "Stateful Switch 1, Stateful Switch 2",
+          "triggerSwitchesNames": "Trigger Switch 1, Trigger Switch 2",
+          "statefulStayOnSwitchesNames": "Stateful Stay-On Switch 1, Stateful Stay-On Switch 2",
+          "triggerStayOnSwitchesNames": "Trigger Stay-On Switch 1, Trigger Stay-On Switch 2",
           "createMasterShutoff": true
         }
     ]
@@ -37,21 +37,25 @@ Also, ideally if you turned on the lights manually they would never turn off (or
 
 That's what this plugin does
 
-This package exposes an occupation sensor with 5 different types of triggers.
+This package exposes an occupation sensor with six different types of triggers. You can combine any of them to create any behavior you'd like. There are four types of simple switches and two types of complex switches.
+Simple Switches:
 - **Stateful (manual) Switch:** These switches activate the occupancy sensor immediately and keep the delay timer from resetting as long as the switch is on.
 - **Trigger Stateless Switch:** These switches activate the occupancy sensor immediately and allow the delay timer to start immediately.
 - **Stateful Stay-on Switches:** These switches will keep the delay timer from starting as long as the switch is on if the occupancy sensor is already on, or they will do nothing if not occupied already.
 - **Trigger Stay-on Switches:** These switches will reset the delay if the occupancy sensor is already on, or they will do nothing if not occupied already.
-- **Master Shutoff Switch:** Master shutoff toggled off kills occupancy immediately when toggled on.
+
+Complex Switches:
+- **"Light" Switch:** These switches are designed to be paired with a light switch in a room where the occupancy sensor is used to turn the lights on (when lights on -> turn on "Light" Switch, when lights off -> turn off "Light" Switch). This switch will ALWAYS match the state of the occupancy sensor. If this type of switch is the one to activate occupancy, occupancy will stay active as long as this switch is turned on. However, if occupancy is triggered by another switch, this "Light" switch will not keep occupancy active (but occupancy will remain active as long as other switches are active). See use case below for more details.
+- **Master Shutoff Switch:** Master shutoff toggled off kills occupancy immediately when toggled on. This will flip all other switches to "off" instantly as well.
 
 
 When the stateful switch is turned on, the occupation sensor is turned on. When the stateful switch then turns off, the occupation sensor stays on for a customizable number of seconds which can be 0 (the Stay Occupied Delay).
 
 When a trigger stateless switch is turned on, it stays on for a second before automatically turning on. When one of these switches turns on, it turns on the occupancy sensor while it's on and the occupancy sensor continues to stay on for the Stay Occupied Delay after the trigger finishes. This one is really useful for triggering with a motion detected event. You can use any combination of actions from these two types of switches to keep the occupation sensor on.
 
-One interesting setting here is the "Ignore Stateful if Turned On By Trigger" setting. If this setting is turned on, if the occupation sensor is activated by a trigger type switch, the stateful (manual) switches will all act like trigger switches for the duration of that occupation cycle. This is very helpful for some complex types of automation.
+The other two types of simple switches, Stateful and Trigger Stay-on Switches, act just like their non Stay-on siblings with one key difference - they can't activate the occupation sensor, only keep it active. These are useful, for example, if you have a hallway light that you want to turn on when the garage opens and keep on then as long as you have motion anywhere in the house (but you wouldn't want motion in the house to normally turn the light on).
 
-The other two types of switches, Stateful and Trigger Stay-on Switches, act just like their non Stay-on siblings with one key difference - they can't activate the occupation sensor, only keep it active. These are useful, for example, if you have a hallway light that you want to turn on when the garage opens and keep on then as long as you have motion anywhere in the house (but you wouldn't want motion in the house to normally turn the light on).
+The icing-on-the-cake switch is the "Light" switch. This switch is the key to the use case above - being able to balance a manual light switch and motion sensor. In essence, a "Light" switch is a stateful switch that is ideal for automation using lights. The key point is that because the switch is turned on automatically whenever motion is detected, it avoids a dead end of "Motion Sensor triggers Occupancy -> Occupancy Triggers Lights On -> Light On triggers a switch on Occupancy -> Motion sensor stops but occupancy stays on forever."
 
 The final switch is the Master Shutoff switch. This switch will instantly turn off all the other switches and turn off the occupancy sensor when turned on. This is helpful for advanced automation use cases.
 
@@ -71,32 +75,32 @@ Here is an example use case for how you can make this switch incredible powerful
           "accessory": "MagicOccupancy",
           "name": "Hallway Occupancy",
           "stayOccupiedDelay": 60,
-          "maxOccupationSeconds": 86400,
-          "statefulSwitchesCount": 1,
-          "triggerSwitchesCount": 1,
-          "motionSwitchesCount": 1,
-          "statefulStayOnSwitchesCount": 1,
-          "triggerStayOnSwitchesCount": 1,
-          "motionStayOnSwitchesCount": 1,
-          "ignoreStatefulIfTurnedOnByTrigger": true,
-          "createMasterShutoff": true
+          "maxOccupationTimeout": 86400,
+          "persistBetweenReboots": true,
+          "startOnReboot": false,
+          "lightSwitchesNames": "Hallway Occupancy Light Switch",
+          "statefulSwitchesNames": "Hallway Occupancy Motion Switch",
+          "triggerSwitchesNames": "Hallway Occupancy Trigger Switch",
+          "statefulStayOnSwitchesNames": "Hallway Occupancy Stay-On Stateful Switch",
+          "triggerStayOnSwitchesNames": "Hallway Occupancy Stay-On Trigger Switch",
+          "createMasterShutoff": false
         }
     ]
 ```
 
 ### HomeKit Automations
-- When Hallway Lights turn on -> Turn on Hallway Occupancy Stateful Switch
-- When Hallway Lights turn off -> Turn off Hallway Occupancy Master Switch
+- When Hallway Lights turn on -> Turn on Hallway Occupancy Light Switch
+- When Hallway Lights turn off -> Turn off Hallway Occupancy Light Switch
 - When Hallway Occupancy Sensor Detects Occupancy -> Turn on Hallway Light
 - When Hallway Occupancy Sensor Stops Detecting Occupancy -> Turn off Hallway Light
 - When Hallway Motion Sensor Detects Motion -> Turn on Hallway Occupancy Motion Switch
 - When Hallway Motion Sensor Stops Detecting Motion -> Turn off Hallway Occupancy Motion Switch
 
 Now, when the Hallway Lights are manually turned on or off, they stay on until the switch is manually turned back off or the maxOccupationSeconds time (86400 seconds=1 day) elapses.
-When the Hallway Lights are turned on by the motion sensor, they automatically turn off stayOccupiedDelay (60 seconds=1 minute) after motion stops (ignoreStatefulIfTurnedOnByTrigger crucially prevents the first automation from keeping the lights on forever).
+When the Hallway Lights are turned on by the motion sensor, they automatically turn off stayOccupiedDelay (60 seconds=1 minute) after motion stops.
 
 ### Additional Advanced HomeKit Automations
-- When Garage Door Is Opened -> Turn on Hallway Trigger Switch
+- When Garage Door Is Opened -> Turn on Hallway Occupancy Trigger Switch
 - When Kitchen Motion Sensor Detects Motion -> Turn on Hallway Occupancy Stay-on Trigger Switch
 - When Dining Room Lights Turn on -> Turn on Hallway Occupancy Stay-on Stateful Switch
 - When Dining Room Lights Turn off -> Turn off Hallway Occupancy Stay-on Stateful Switch

--- a/config.schema.json
+++ b/config.schema.json
@@ -31,52 +31,51 @@
                 "title": "Absolute Max Occupation Time (auto-shutoff)",
                 "type": "number"
             },
-            "statefulSwitchesCount": {
+            "lightSwitchesNames": {
                 "default": 1,
+                "description": "These switches should be directly linked to light switches (on=on, off=off) and will act like a hybrid of stateful and master shutoff switches",
+                "title": "Names of Motion Switches (Separate by comma)",
+                "type": "string"
+            },
+            "statefulSwitchesNames": {
+                "default": 0,
                 "description": "These switches activate the occupancy sensor immediately and keep the delay timer from resetting as long as the switch is on.",
-                "title": "Number of Stateful (manual) Switches",
-                "type": "number"
+                "title": "Names of Stateful (manual) Switches (Separate by comma)",
+                "type": "string"
             },
-            "triggerSwitchesCount": {
-                "default": 1,
+            "triggerSwitchesNames": {
+                "default": 0,
                 "description": "These switches activate the occupancy sensor immediately and allow the delay timer to start immediately.",
-                "title": "Number of Trigger Stateless Switches",
-                "type": "number"
+                "title": "Names of Trigger Stateless Switches (Separate by comma)",
+                "type": "string"
             },
-            "motionSwitchesCount": {
-                "default": 1,
+            "motionSwitchesNames": {
+                "default": 0,
                 "description": "These switches should be directly linked to motion sensors (on=on, off=off) and will act like a hybrid of stateful and trigger switches.",
-                "title": "Number of Motion Switches",
-                "type": "number"
+                "title": "Names of Motion Switches (Separate by comma)",
+                "type": "string"
             },
-            "statefulStayOnSwitchesCount": {
-                "default": 1,
+            "statefulStayOnSwitchesNames": {
+                "default": 0,
                 "description": "These switches will keep the delay timer from starting as long as the switch is on if the occupancy sensor is already on, or they will do nothing if not occupied already.",
-                "title": "Number of Stateful Stay-on Switches",
-                "type": "number"
+                "title": "Names of Stateful Stay-on Switches (Separate by comma)",
+                "type": "string"
             },
-            "triggerStayOnSwitchesCount": {
-                "default": 1,
+            "triggerStayOnSwitchesNames": {
+                "default": 0,
                 "description": "These switches will reset the delay if the occupancy sensor is already on, or they will do nothing if not occupied already.",
-                "title": "Number of Trigger Stateless Stay-on Switches",
-                "type": "number"
+                "title": "Names of Trigger Stateless Stay-on Switches (Separate by comma)",
+                "type": "string"
             },
-            "motionStayOnSwitchesCount": {
-                "default": 1,
+            "motionStayOnSwitchesNames": {
+                "default": 0,
                 "description": "These switches should be directly linked to motion sensors (on=on, off=off) and will act like a hybrid of stateful and trigger switches. They will reset the delay if the occupancy sensor is already on, or they will do nothing if not occupied already.",
-                "title": "Number of Motion Stay-on Switches",
-                "type": "number"
-            },
-            "ignoreStatefulIfTurnedOnByTrigger": {
-                "required": true,
-                "default": true,
-                "description": "Whether or not stateful switches should be treated like trigger switches if occupation was turned on by a trigger switch.",
-                "title": "Ignore Stateful if Turned On By Trigger",
-                "type": "boolean"
+                "title": "Names of Motion Stay-on Switches (Separate by comma)",
+                "type": "string"
             },
             "createMasterShutoff": {
                 "required": true,
-                "default": true,
+                "default": false,
                 "description": "Whether or not to create a master shutoff switch. Master shutoff toggled off kills occupancy immediately when toggled on.",
                 "title": "Create Master Shutoff",
                 "type": "boolean"

--- a/config.schema.json
+++ b/config.schema.json
@@ -32,43 +32,43 @@
                 "type": "number"
             },
             "lightSwitchesNames": {
-                "default": 1,
+                "default": "LightSwitch",
                 "description": "These switches should be directly linked to light switches (on=on, off=off) and will act like a hybrid of stateful and master shutoff switches",
                 "title": "Names of Motion Switches (Separate by comma)",
                 "type": "string"
             },
             "statefulSwitchesNames": {
-                "default": 0,
+                "default": "",
                 "description": "These switches activate the occupancy sensor immediately and keep the delay timer from resetting as long as the switch is on.",
                 "title": "Names of Stateful (manual) Switches (Separate by comma)",
                 "type": "string"
             },
             "triggerSwitchesNames": {
-                "default": 0,
+                "default": "",
                 "description": "These switches activate the occupancy sensor immediately and allow the delay timer to start immediately.",
                 "title": "Names of Trigger Stateless Switches (Separate by comma)",
                 "type": "string"
             },
             "motionSwitchesNames": {
-                "default": 0,
+                "default": "MotionSensor",
                 "description": "These switches should be directly linked to motion sensors (on=on, off=off) and will act like a hybrid of stateful and trigger switches.",
                 "title": "Names of Motion Switches (Separate by comma)",
                 "type": "string"
             },
             "statefulStayOnSwitchesNames": {
-                "default": 0,
+                "default": "",
                 "description": "These switches will keep the delay timer from starting as long as the switch is on if the occupancy sensor is already on, or they will do nothing if not occupied already.",
                 "title": "Names of Stateful Stay-on Switches (Separate by comma)",
                 "type": "string"
             },
             "triggerStayOnSwitchesNames": {
-                "default": 0,
+                "default": "",
                 "description": "These switches will reset the delay if the occupancy sensor is already on, or they will do nothing if not occupied already.",
                 "title": "Names of Trigger Stateless Stay-on Switches (Separate by comma)",
                 "type": "string"
             },
             "motionStayOnSwitchesNames": {
-                "default": 0,
+                "default": "",
                 "description": "These switches should be directly linked to motion sensors (on=on, off=off) and will act like a hybrid of stateful and trigger switches. They will reset the delay if the occupancy sensor is already on, or they will do nothing if not occupied already.",
                 "title": "Names of Motion Stay-on Switches (Separate by comma)",
                 "type": "string"

--- a/config.schema.json
+++ b/config.schema.json
@@ -14,6 +14,11 @@
                 "title": "Stay Occupied Delay",
                 "type": "number"
             },
+            "maxOccupationTimeout": {
+                "description": "How long in seconds is the absolute max time a room can stay occupied for (regardless of switch activity). Set 0 or blank to run forever.",
+                "title": "Absolute Max Occupation Time (auto-shutoff)",
+                "type": "number"
+            },
             "persistBetweenReboots": {
                 "default": true,
                 "description": "Whether the occupancy sensor and its switches should restore their previous states on Homebridge restart",
@@ -26,14 +31,9 @@
                 "title": "Always Start as Occupied on Reboot",
                 "type": "boolean"
             },
-            "maxOccupationTimeout": {
-                "description": "How long in seconds is the absolute max time a room can stay occupied for (regardless of switch activity). Set 0 or blank to run forever.",
-                "title": "Absolute Max Occupation Time (auto-shutoff)",
-                "type": "number"
-            },
             "lightSwitchesNames": {
                 "default": "",
-                "description": "These switches should be directly linked to light switches (on=on, off=off) and will act like a hybrid of stateful and master shutoff switches",
+                "description": "These switches should be directly linked to light switches (on=on, off=off) and will act like a hybrid of stateful and master shutoff switches. See Readme for more info.",
                 "title": "Names of Light Switches (Separate by comma)",
                 "type": "string"
             },
@@ -49,12 +49,6 @@
                 "title": "Names of Trigger Stateless Switches (Separate by comma)",
                 "type": "string"
             },
-            "motionSwitchesNames": {
-                "default": "",
-                "description": "These switches should be directly linked to motion sensors (on=on, off=off) and will act like a hybrid of stateful and trigger switches.",
-                "title": "Names of Motion Switches (Separate by comma)",
-                "type": "string"
-            },
             "statefulStayOnSwitchesNames": {
                 "default": "",
                 "description": "These switches will keep the delay timer from starting as long as the switch is on if the occupancy sensor is already on, or they will do nothing if not occupied already.",
@@ -65,12 +59,6 @@
                 "default": "",
                 "description": "These switches will reset the delay if the occupancy sensor is already on, or they will do nothing if not occupied already.",
                 "title": "Names of Trigger Stateless Stay-on Switches (Separate by comma)",
-                "type": "string"
-            },
-            "motionStayOnSwitchesNames": {
-                "default": "",
-                "description": "These switches should be directly linked to motion sensors (on=on, off=off) and will act like a hybrid of stateful and trigger switches. They will reset the delay if the occupancy sensor is already on, or they will do nothing if not occupied already.",
-                "title": "Names of Motion Stay-on Switches (Separate by comma)",
                 "type": "string"
             },
             "createMasterShutoff": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -32,7 +32,7 @@
                 "type": "number"
             },
             "lightSwitchesNames": {
-                "default": "LightSwitch",
+                "default": "",
                 "description": "These switches should be directly linked to light switches (on=on, off=off) and will act like a hybrid of stateful and master shutoff switches",
                 "title": "Names of Motion Switches (Separate by comma)",
                 "type": "string"
@@ -50,7 +50,7 @@
                 "type": "string"
             },
             "motionSwitchesNames": {
-                "default": "MotionSensor",
+                "default": "",
                 "description": "These switches should be directly linked to motion sensors (on=on, off=off) and will act like a hybrid of stateful and trigger switches.",
                 "title": "Names of Motion Switches (Separate by comma)",
                 "type": "string"

--- a/config.schema.json
+++ b/config.schema.json
@@ -34,7 +34,7 @@
             "lightSwitchesNames": {
                 "default": "",
                 "description": "These switches should be directly linked to light switches (on=on, off=off) and will act like a hybrid of stateful and master shutoff switches",
-                "title": "Names of Motion Switches (Separate by comma)",
+                "title": "Names of Light Switches (Separate by comma)",
                 "type": "string"
             },
             "statefulSwitchesNames": {

--- a/index.js
+++ b/index.js
@@ -62,6 +62,28 @@ module.exports = function (homebridge) {
   inherits(Characteristic.TimeoutDelay, Characteristic);
   Characteristic.TimeoutDelay.UUID = "2100006D-0000-1000-8000-0026BB765291";
 
+    /**
+   * Characteristic "Keeping Occupancy Triggered"
+   */
+  Characteristic.KeepingOccupancyTriggered = function () {
+    Characteristic.call(
+      this,
+      "Keeping Occupancy Triggered",
+      "25eb64e4-e104-11eb-ba80-0242ac130004"
+    );
+    this.setProps({
+      format: Characteristic.Formats.BOOL,
+      perms: [
+        Characteristic.Perms.READ,
+        Characteristic.Perms.WRITE,
+        Characteristic.Perms.NOTIFY,
+      ],
+    });
+    this.value = this.getDefaultValue();
+  };
+  inherits(Characteristic.KeepingOccupancyTriggered, Characteristic);
+  Characteristic.KeepingOccupancyTriggered.UUID = "25eb64e4-e104-11eb-ba80-0242ac130004";
+
   // Register
   homebridge.registerAccessory(
     "homebridge-magic-occupancy",
@@ -74,18 +96,17 @@ class MagicOccupancy {
   constructor(log, config) {
     this.log = log;
     this.name = config.name || "MagicOccupancy";
-    this.statefulSwitchesCount = Math.max(0, config.statefulSwitchesCount || 0);
-    this.triggerSwitchesCount = Math.max(0, config.triggerSwitchesCount || 0);
-    this.motionSwitchesCount = Math.max(0, config.motionSwitchesCount || 0);
-    this.statefulStayOnSwitchesCount = Math.max(0, config.statefulStayOnSwitchesCount || 0);
-    this.triggerStayOnSwitchesCount = Math.max(0, config.triggerStayOnSwitchesCount || 0);
-    this.motionStayOnSwitchesCount = Math.max(0, config.motionStayOnSwitchesCount || 0);
+    this.lightSwitchesNames = (config.lightSwitchesNames || "").split(",");
+    this.statefulSwitchesNames = (config.statefulSwitchesNames || "").split(",");
+    this.triggerSwitchesNames = (config.triggerSwitchesNames || "").split(",");
+    this.motionSwitchesNames = (config.motionSwitchesNames || "").split(",");
+    this.statefulStayOnSwitchesNames = (config.statefulStayOnSwitchesNames || "").split(",");
+    this.triggerStayOnSwitchesNames = (config.triggerStayOnSwitchesNames || "").split(",");
+    this.motionStayOnSwitchesNames = (config.motionStayOnSwitchesNames || "").split(",");
     this.stayOccupiedDelay = Math.min(3600, Math.max(0, parseInt(config.stayOccupiedDelay || 0, 10) || 0));
     this.maxOccupationTimeout = Math.max(0, parseInt(config.maxOccupationTimeout || 0, 10) || 0)
-    this.ignoreStatefulIfTurnedOnByTrigger = (config.ignoreStatefulIfTurnedOnByTrigger == true);
     this.persistBetweenReboots = config.persistBetweenReboots != false;
     this.startOnReboot = config.startOnReboot || false;
-    this.wasTurnedOnByTriggerSwitch = false;
     this.triggerSwitchToggleTimeout = 1000;
     this.initializationCompleted = false;
     this.locksCounter = 0;
@@ -114,13 +135,11 @@ class MagicOccupancy {
     this._last_occupied_state = savedState._last_occupied_state;
 
     this.switchServices = [];
-    this.stayOnServices = [];
     this.occupancyService = new Service.OccupancySensor(this.name);
     this.informationService = new Service.AccessoryInformation()
       .setCharacteristic(Characteristic.Manufacturer, "https://github.com/Jason-Morcos/homebridge-magic-occupancy")
       .setCharacteristic(Characteristic.Model, "2")
       .setCharacteristic(Characteristic.SerialNumber, "JmoMagicOccupancySwitch");
-    this.masterShutoffService = null;
 
     this.occupancyService.addCharacteristic(Characteristic.TimeoutDelay);
     this.occupancyService.setCharacteristic(
@@ -154,83 +173,83 @@ class MagicOccupancy {
         }
       });
 
-    /* Make the statefulSwitches */
-    if(this.statefulSwitchesCount > 0) {
-      this.log.debug("Making " + this.statefulSwitchesCount + " Stateful trigger switchServices");
-      for (let i = 0, c = this.statefulSwitchesCount; i < c; i += 1) {
-        this.switchServices.push((new OccupancyTriggerSwitch(this, {
-            name: "Main Stateful " + i.toString(),
+    /* Make the lightSwitches */
+    if(this.lightSwitchesNames.length > 0) {
+      this.log.debug("Making " + this.lightSwitchesNames.length + " Light Switch switchServices");
+      this.lightSwitchesNames.forEach(function(switchName) {
+        this.switchServices.push((new LightSwitchMirrorSwitch(this, {
+            name: switchName,
             stayOnOnly: false,
-            isTrigger: false,
-            isMotion: false,
         }))._service);
-      }
+      }.bind(this));
+    }
+    /* Make the statefulSwitches */
+    if(this.statefulSwitchesNames.length > 0) {
+      this.log.debug("Making " + this.statefulSwitchesNames.length + " Stateful trigger switchServices");
+      this.statefulSwitchesNames.forEach(function(switchName) {
+        this.switchServices.push((new StatefulSwitch(this, {
+            name: switchName,
+            stayOnOnly: false,
+        }))._service);
+      }.bind(this));
     }
     /* Make the triggerSwitches */
-    if(this.triggerSwitchesCount > 0) {
-      this.log.debug("Making " + this.triggerSwitchesCount + " Trigger trigger switchServices");
-      for (let i = 0, c = this.triggerSwitchesCount; i < c; i += 1) {
-        this.switchServices.push((new OccupancyTriggerSwitch(this, {
-            name: "Main Trigger " + i.toString(),
+    if(this.triggerSwitchesNames.length > 0) {
+      this.log.debug("Making " + this.triggerSwitchesNames.length + " Trigger trigger switchServices");
+      this.triggerSwitchesNames.forEach(function(switchName) {
+        this.switchServices.push((new TriggerSwitch(this, {
+            name: switchName,
             stayOnOnly: false,
-            isTrigger: true,
-            isMotion: false,
         }))._service);
-      }
+      }.bind(this));
     }
     /* Make the motionSwitches */
-    if(this.motionSwitchesCount > 0) {
-      this.log.debug("Making " + this.motionSwitchesCount + " Motion trigger switchServices");
-      for (let i = 0, c = this.motionSwitchesCount; i < c; i += 1) {
-        this.switchServices.push((new OccupancyTriggerSwitch(this, {
-            name: "Main Motion " + i.toString(),
+    if(this.motionSwitchesNames.length > 0) {
+      this.log.debug("Making " + this.motionSwitchesNames.length + " Motion trigger switchServices");
+      this.motionSwitchesNames.forEach(function(switchName) {
+        this.switchServices.push((new MotionSensorSwitch(this, {
+            name: switchName,
             stayOnOnly: false,
-            isTrigger: true,
-            isMotion: true,
         }))._service);
-      }
+      }.bind(this));
     }
 
     /* Make the statefulStayOnSwitches */
-    if(this.statefulStayOnSwitchesCount > 0) {
-      this.log.debug("Making " + this.statefulStayOnSwitchesCount + " StayOn Stateful trigger switchServices");
-      for (let i = 0, c = this.statefulStayOnSwitchesCount; i < c; i += 1) {
-        this.stayOnServices.push((new OccupancyTriggerSwitch(this, {
-            name: "StayOn Stateful " + i.toString(),
+    if(this.statefulStayOnSwitchesNames.length > 0) {
+      this.log.debug("Making " + this.statefulStayOnSwitchesNames.length + " StayOn Stateful trigger switchServices");
+      this.statefulStayOnSwitchesNames.forEach(function(switchName) {
+        this.switchServices.push((new StatefulSwitch(this, {
+            name: switchName,
             stayOnOnly: true,
-            isTrigger: false,
-            isMotion: false,
         }))._service);
-      }
+      }.bind(this));
     }
     /* Make the triggerStayOnSwitches */
-    if(this.triggerStayOnSwitchesCount > 0) {
-      this.log.debug("Making " + this.triggerStayOnSwitchesCount + " StayOn Trigger trigger switchServices");
-      for (let i = 0, c = this.triggerStayOnSwitchesCount; i < c; i += 1) {
-        this.stayOnServices.push((new OccupancyTriggerSwitch(this, {
-            name: "StayOn Trigger " + i.toString(),
+    if(this.triggerStayOnSwitchesNames.length > 0) {
+      this.log.debug("Making " + this.triggerStayOnSwitchesNames.length + " StayOn Trigger trigger switchServices");
+      this.triggerStayOnSwitchesNames.forEach(function(switchName) {
+        this.switchServices.push((new TriggerSwitch(this, {
+            name: switchName,
             stayOnOnly: true,
-            isTrigger: true,
-            isMotion: false,
         }))._service);
-      }
+      }.bind(this));
     }
     /* Make the motionStayOnSwitches */
-    if(this.motionStayOnSwitchesCount > 0) {
-      this.log.debug("Making " + this.motionStayOnSwitchesCount + " StayOn Motion trigger switchServices");
-      for (let i = 0, c = this.motionStayOnSwitchesCount; i < c; i += 1) {
-        this.stayOnServices.push((new OccupancyTriggerSwitch(this, {
-            name: "StayOn Motion " + i.toString(),
+    if(this.motionStayOnSwitchesNames.length > 0) {
+      this.log.debug("Making " + this.motionStayOnSwitchesNames.length + " StayOn Motion trigger switchServices");
+      this.motionStayOnSwitchesNames.forEach(function(switchName) {
+        this.switchServices.push((new MotionSensorSwitch(this, {
+            name: switchName,
             stayOnOnly: true,
-            isTrigger: true,
-            isMotion: true,
         }))._service);
-      }
+      }.bind(this));
     }
 
     //Create master shutoff
     if(config.createMasterShutoff == true) {
-      this.masterShutoffService = (new MasterShutoffSwitch(this))._service;
+      this.switchServices.push((new MasterShutoffSwitch(this, {
+            name: "Master Shutoff",
+        }))._service);
     }
 
     //Mark that we're done initializing here, final setup below
@@ -384,9 +403,6 @@ class MagicOccupancy {
     this.locksCounter += 1;
     this.stop();
 
-    //Reset was turned on by trigger
-    this.wasTurnedOnByTriggerSwitch = false;
-
     this.occupancyService.setCharacteristic(
       Characteristic.OccupancyDetected,
       Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED
@@ -424,9 +440,6 @@ class MagicOccupancy {
     for (let i = 0; i < this.switchServices.length; i += 1) {
       shutoff_switch(this.switchServices[i]);
     }
-    for (let i = 0; i < this.stayOnServices.length; i += 1) {
-      shutoff_switch(this.stayOnServices[i]);
-    }
 
     //Save state
     this.saveCachedState("_MAIN", {
@@ -461,67 +474,73 @@ class MagicOccupancy {
     }
 
     this.locksCounter += 1;
-    this.log.debug(`checking occupancy. Total: ${this.switchServices.length}`);
 
-    var switchesToCheck = [];
-    switchesToCheck.push(...this.switchServices);
-    //Stay-on switches only honored if we're already on
-    if(this._last_occupied_state === true) {
-      switchesToCheck.push(...this.stayOnServices);
-    }
+    const switchesToCheck = this.switchServices;
+    const previousOccupiedState = this._last_occupied_state;
+    this.log.debug(`checking occupancy. Total: ${switchesToCheck.length} switches`);
 
     /* callback for when all the switchServices values have been returned */
-    var return_occupancy = (occupiedSwitchCount) => {
-      const previousOccupiedState = this._last_occupied_state;
+    var result = {'already_acted': false, 'remainingCount': switchesToCheck.length};
 
-      if (occupiedSwitchCount > 0) {
-        this.setOccupancyDetected();
-      } else if (this._timer === null) {
-        this.startUnoccupiedDelay();
+    var handleResponse = function(value) {
+      result.remainingCount -= 1;
+
+      if(result.already_acted) {
+        return;
       }
 
-      this.log(
-        `checkOccupancy result: ${occupiedSwitchCount}. Previous occupied state: ${previousOccupiedState}, current: ${this._last_occupied_state}`
-      );
+      if(value == true) {
+        result.already_acted = true;
 
-    };
+        if(this._last_occupied_state == false) {
+          this.setOccupancyDetected();
 
-    /*
-        callback when we check a switchServices value. keeps track of the switchServices
-        returned value and decides when to finish the function
-      */
-    var remainingCount = switchesToCheck.length;
-    var occupiedSwitchCount = 0;
-    var set_occupancy_switch_value_result = (value) => {
-      this.log.debug(`Remaining Switches: ${remainingCount}, value: ${value}`);
-      remainingCount -= 1;
-      if (value) {
-        occupiedSwitchCount += 1;
+        }
+
+        this.log(
+          `checkOccupancy result: true. Previous occupied state: ${previousOccupiedState}, current state: ${this._last_occupied_state}`
+        );
       }
 
-      if (remainingCount == 0) {
-        return_occupancy(occupiedSwitchCount);
-      }
-    };
+      if(value == false && result.remainingCount == 0) {
+        result.already_acted = true;
 
-    /* look at all the trigger switchServices "on" characteristic and return to callback */
+        if(this._last_occupied_state == true && this._timer === null) {
+          this.startUnoccupiedDelay();
+        }
+
+        this.log(
+          `checkOccupancy result: false. Previous occupied state: ${previousOccupiedState}, current state: ${this._last_occupied_state}`
+        );
+      }
+    }.bind(this);
+
+    /* look at all the trigger switchServices "KeepingOccupancyTriggered" characteristic and return to callback */
     for (let i = 0; i < switchesToCheck.length; i += 1) {
+      if(result.already_acted) {
+        break;
+      }
+
       switchesToCheck[i]
-          .getCharacteristic(Characteristic.On)
-          .getValue(function(err, value) {
-            if (!err) {
-              set_occupancy_switch_value_result(value);
-            } else {
-              this.log(
-                `ERROR GETTING VALUE ${err}`
-              );
-              set_occupancy_switch_value_result(false);
-            }
-          });
+        .getCharacteristic(Characteristic.KeepingOccupancyTriggered)
+        .getValue(function(err, value) {
+          if (err) {
+            this.log(
+              `ERROR GETTING VALUE ${err}`
+            );
+            value = false;
+          }
+
+          handleResponse(value);
+      });
     }
 
-    if(switchesToCheck.length == 0) {
-      return_occupancy(0);
+    if(switchesToCheck.length == 0 && this._last_occupied_state == true) {
+      this.startUnoccupiedDelay();
+
+      this.log(
+        `checkOccupancy result: false (0 switches). Previous occupied state: ${previousOccupiedState}, current state: ${this._last_occupied_state}`
+      );
     }
 
     this.locksCounter -= 1;
@@ -535,35 +554,56 @@ class MagicOccupancy {
    */
   getServices() {
     var services = [this.occupancyService, this.informationService];
-    if(this.masterShutoffService != null) {
-      services.push(this.masterShutoffService);
-    }
 
-    return services.concat([...this.switchServices, ...this.stayOnServices]);
+    return services.concat([...this.switchServices]);
   }
 }
 
-class OccupancyTriggerSwitch {
+
+class BaseHelperSwitch {
   constructor(occupancySensor, config) {
     this.log = occupancySensor.log;
     this.occupancySensor = occupancySensor;
     this.name = occupancySensor.name + " " + config.name;
-    this.stayOnOnly = config.stayOnOnly;
-    this.isMotion = config.isMotion;
-    this.isTrigger = config.isTrigger || config.isMotion;
-    this.stateful = !config.isTrigger;
-    this.timer = null;
     this._service = new Service.Switch(this.name, this.name);
 
-    this._service.getCharacteristic(Characteristic.On)
-      .on('set', this._setOn.bind(this));
+    this._offDelayTimer = null;
 
-    if (this.stateful) {
-      this._service.setCharacteristic(Characteristic.On, this.occupancySensor.getCachedState('SW-' + this.name, false));
-    }
+
+    this._service.setCharacteristic(Characteristic.On, this.occupancySensor.getCachedState('PMS-' + this.name, false));
+
+    this._service.addCharacteristic(Characteristic.KeepingOccupancyTriggered);
+    this.keepingOccupancyTriggered = this.occupancySensor.getCachedState('PMS-KOT-' + this.name, false);
+    this._service.setCharacteristic(
+      Characteristic.KeepingOccupancyTriggered,
+      this.keepingOccupancyTriggered
+    );
+
+    //Attach to changes
+    this._service.getCharacteristic(Characteristic.On)
+      .on('set', this._internalStateChangeTrigger.bind(this));
+
   }
 
-  _setOn(on, callback) {
+  _killOccupancy() {
+    this.occupancySensor.locksCounter += 1;
+      this.occupancySensor.setOccupancyNotDetected();
+      setTimeout(function() {
+        this.occupancySensor.checkOccupancy();
+        this.occupancySensor.locksCounter -= 1;
+      }.bind(this), 10);
+  }
+
+  _setOccupancyOn() {
+    this.occupancySensor.locksCounter += 1;
+    this.occupancySensor.setOccupancyDetected();
+    setTimeout(function() {
+      this.occupancySensor.checkOccupancy();
+      this.occupancySensor.locksCounter -= 1;
+    }.bind(this), 10);
+  }
+
+  _internalStateChangeTrigger(on, callback) {
     //Make sure we're actually full initialized
     if(!this.occupancySensor.initializationCompleted) {
       this.log.debug("Setting " + this.name + " initial state and bypassing all events");
@@ -571,88 +611,156 @@ class OccupancyTriggerSwitch {
       return;
     }
 
-    //Cache our previous state for restoration
-    if (this.stateful) {
-      this.occupancySensor.saveCachedState('SW-' + this.name, on);
+    //Handle off switch canceling timer
+    if(off && this._offDelayTimer) {
+      clearTimeout(this._offDelayTimer);
+      this._offDelayTimer = null;
     }
 
-    //Early return to break out on shutoff events when all switches are shutoff (like if master shutoff is triggered)
-    if(!on && this.occupancySensor._last_occupied_state === false) {
-      this.log.debug("Setting " + this.name + " to off and bypassing all events");
-      callback();
+    //Cache our previous state for restoration
+    this.occupancySensor.saveCachedState('PMS-' + this.name, on);
+
+    this._handleNewState(on);
+
+    callback();
+  }
+
+  _setKeepingOccupancyTriggered(newVal) {
+    this.keepingOccupancyTriggered = newVal;
+    this._service.setCharacteristic(Characteristic.KeepingOccupancyTriggered, newVal);
+    this.occupancySensor.saveCachedState('PMS-KOT-' + this.name, newVal);
+  }
+
+  _handleNewState(on) {
+    //Overwritten in child classes
+  }
+}
+
+class StatefulSwitch extends BaseHelperSwitch {
+  constructor(occupancySensor, config) {
+    super(occupancySensor, config);
+    this.stayOnOnly = config.stayOnOnly || false;
+  }
+
+  _handleNewState(on) {
+    if(!on && !this.keepingOccupancyTriggered) {
       return;
     }
 
-    //If we're being turned on by a non-stateful switch, we need to know that - this means we should disable stateful switches
-    if(on && this.occupancySensor._last_occupied_state === false && this.isTrigger && !this.stayOnOnly) {
-      //Non-stateful switches
-      this.occupancySensor.wasTurnedOnByTriggerSwitch = true;
-      this.log("Setting wasTurnedOnByTriggerSwitch to true due to " + this.name);
+    const isValidOn = on && (!this.stayOnOnly || this.occupancySensor._last_occupied_state == true);
+
+    this._setKeepingOccupancyTriggered(isValidOn);
+
+    if(isValidOn) {
+      this._setOccupancyOn();
     }
 
-    this.log.debug("Setting switch " + this.name + " to " + on);
+    if(off && this.occupancySensor._last_occupied_state == true) {
+      this.occupancySensor.checkOccupancy(10);
+    }
+  }
+}
 
-    //After a delay, if we were turned on by a trigger switch flip me back off
-    if(!this.isMotion) {
-      clearTimeout(this.timer)
-      this.timer = setTimeout(function() {
-        var treatStateful = this.stateful;
-        if(this.stateful && this.occupancySensor.wasTurnedOnByTriggerSwitch && this.occupancySensor.ignoreStatefulIfTurnedOnByTrigger) {
-          this.log("Treating stateful action to " + this.name + " as trigger due to wasTurnedOnByTriggerSwitch and ignoreStatefulIfTurnedOnByTrigger");
-          treatStateful = false;
-        }
+class TriggerSwitch extends BaseHelperSwitch {
+  constructor(occupancySensor, config) {
+    super(occupancySensor, config);
+    this.stayOnOnly = config.stayOnOnly || false;
+    this._setKeepingOccupancyTriggered(false);
+  }
 
-        if (!treatStateful && on) {
-          this._service.setCharacteristic(Characteristic.On, false);
-        }
+  _handleNewState(on) {
+    if(!on && !this.keepingOccupancyTriggered) {
+      return;
+    }
+
+    if(on && (!this.stayOnOnly || this.occupancySensor._last_occupied_state == true)) {
+      this._setOccupancyOn();
+    }
+
+    if(on) {
+      this._offDelayTimer = setTimeout(function() {
+        this._service.setCharacteristic(Characteristic.On, false);
       }.bind(this), this.occupancySensor.triggerSwitchToggleTimeout);
     }
+  }
+}
 
-    callback();
 
-    //Only dispatch appropriate events - all events from non stay-on and only from stay ons when on
-    if(!this.stayOnOnly || this.occupancySensor._last_occupied_state === true) {
+class MotionSensorSwitch extends BaseHelperSwitch {
+  constructor(occupancySensor, config) {
+    super(occupancySensor, config);
+    this.stayOnOnly = config.stayOnOnly || false;
+  }
+
+  _handleNewState(on) {
+    if(!on && !this.keepingOccupancyTriggered) {
+      return;
+    }
+
+    const isValidOn = on && (!this.stayOnOnly || this.occupancySensor._last_occupied_state == true);
+
+    this._setKeepingOccupancyTriggered(isValidOn);
+
+    if(isValidOn) {
+      this._setOccupancyOn();
+    }
+
+    if(off && this.occupancySensor._last_occupied_state == true) {
       this.occupancySensor.checkOccupancy(10);
     }
   }
 }
 
 
-class MasterShutoffSwitch {
-  constructor(occupancySensor) {
-    this.log = occupancySensor.log;
-    this.occupancySensor = occupancySensor;
-    this.name = occupancySensor.name + " Master Shutoff";
-    this._service = new Service.Switch(this.name, this.name);
+class LightSwitchMirrorSwitch extends BaseHelperSwitch {
+  constructor(occupancySensor, config) {
+    super(occupancySensor, config);
 
-    this._service.setCharacteristic(Characteristic.On, false);
-    this._service.getCharacteristic(Characteristic.On)
-      .on('set', this._setOn.bind(this));
-
+    //Make this switch match the big boi
+    this.occupancySensor.occupancyService.getCharacteristic(Characteristic.OccupancyDetected)
+      .on('set', function(occVal, callback) {
+        this._service.getValue(function(err, value) {
+            if (!err) {
+              if(value != (occVal == Characteristic.OccupancyDetected.OCCUPANCY_DETECTED)) {
+                this._service.setCharacteristic(Characteristic.On, (occVal == Characteristic.OccupancyDetected.OCCUPANCY_DETECTED));
+              }
+            } else {
+              this.log(
+                `ERROR GETTING VALUE ${err}`
+              );
+            }
+          });
+      }.bind(this))
   }
 
-  _setOn(on, callback) {
-    //Make sure we're actually full initialized
-    if(!this.occupancySensor.initializationCompleted) {
-      callback();
-      return;
+  _handleNewState(on) {
+    if(on && this.occupancySensor._last_occupied_state == false) {
+      this._setKeepingOccupancyTriggered(true);
+
+      this._setOccupancyOn();
     }
 
+    //Handle turning off the whole system with this switch
+    if(off) {
+      this._setKeepingOccupancyTriggered(false);
+      this._killOccupancy();
+    }
+  }
+}
 
+
+class MasterShutoffSwitch extends BaseHelperSwitch {
+  constructor(occupancySensor, config) {
+    super(occupancySensor, config);
+    this._setKeepingOccupancyTriggered(false);
+  }
+
+  _handleNewState(on) {
+    this._killOccupancy();
     if(on) {
-      this.log("Setting master shutoff switch to on, killing everything");
-
-      this.occupancySensor.locksCounter += 1;
-
-      this.occupancySensor.setOccupancyNotDetected();
-      setTimeout(function() {
+      this._offDelayTimer = setTimeout(function() {
         this._service.setCharacteristic(Characteristic.On, false);
-        this.occupancySensor.checkOccupancy();
-        this.occupancySensor.locksCounter -= 1;
       }.bind(this), this.occupancySensor.triggerSwitchToggleTimeout);
-
     }
-
-    callback();
   }
 }

--- a/index.js
+++ b/index.js
@@ -669,7 +669,7 @@ class StatefulSwitch extends BaseHelperSwitch {
   }
 
   _getIsKeepingOccupancyTriggered() {
-    return this._is_on && (!config.stayOnOnly || this.occupancySensor._last_occupied_state == true);
+    return this._is_on && (!this.stayOnOnly || this.occupancySensor._last_occupied_state == true);
   }
 }
 
@@ -716,7 +716,7 @@ class MotionSensorSwitch extends BaseHelperSwitch {
   }
 
   _getIsKeepingOccupancyTriggered() {
-    return this._is_on && (!config.stayOnOnly || this.occupancySensor._last_occupied_state == true);
+    return this._is_on && (!this.stayOnOnly || this.occupancySensor._last_occupied_state == true);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -753,7 +753,7 @@ class LightSwitchMirrorSwitch extends BaseHelperSwitch {
             if(value != (occVal == Characteristic.OccupancyDetected.OCCUPANCY_DETECTED)) {
               this._service.setCharacteristic(Characteristic.On, (occVal == Characteristic.OccupancyDetected.OCCUPANCY_DETECTED));
             }
-          });
+          }.bind(this));
       }.bind(this))
   }
 

--- a/index.js
+++ b/index.js
@@ -728,6 +728,8 @@ class LightSwitchMirrorSwitch extends BaseHelperSwitch {
     //Make this switch match the big boi
     this.occupancySensor.occupancyService.getCharacteristic(Characteristic.OccupancyDetected)
       .on('set', function(occVal, callback) {
+        callback();
+
         this._service
           .getCharacteristic(Characteristic.On)
           .getValue(function(err, value) {
@@ -742,6 +744,7 @@ class LightSwitchMirrorSwitch extends BaseHelperSwitch {
               this._service.setCharacteristic(Characteristic.On, this.occupancySensor._last_occupied_state);
             }
           }.bind(this));
+
       }.bind(this))
   }
 

--- a/index.js
+++ b/index.js
@@ -547,7 +547,7 @@ class MagicOccupancy {
         .getValue(function(err, value) {
           if (err) {
             this.log(
-              `ERROR GETTING VALUE ${err}`
+              `ERROR GETTING VALUE Characteristic.KeepingOccupancyTriggered ${err}`
             );
             value = false;
           }
@@ -608,11 +608,11 @@ class BaseHelperSwitch {
 
   _killOccupancy() {
     this.occupancySensor.locksCounter += 1;
-      this.occupancySensor.setOccupancyNotDetected();
-      setTimeout(function() {
-        this.occupancySensor.checkOccupancy();
-        this.occupancySensor.locksCounter -= 1;
-      }.bind(this), 10);
+    this.occupancySensor.setOccupancyNotDetected();
+    setTimeout(function() {
+      this.occupancySensor.checkOccupancy();
+      this.occupancySensor.locksCounter -= 1;
+    }.bind(this), 10);
   }
 
   _setOccupancyOn() {
@@ -743,9 +743,9 @@ class LightSwitchMirrorSwitch extends BaseHelperSwitch {
         this._service
           .getCharacteristic(Characteristic.On)
           .getValue(function(err, value) {
-            if (!err) {
+            if (err) {
               this.log(
-                `ERROR GETTING VALUE ${err}`
+                `ERROR GETTING VALUE Characteristic.On ${err}`
               );
               return;
             }
@@ -780,8 +780,8 @@ class MasterShutoffSwitch extends BaseHelperSwitch {
   }
 
   _handleNewState(on) {
-    this._killOccupancy();
     if(on) {
+      this._killOccupancy();
       this._offDelayTimer = setTimeout(function() {
         this._service.setCharacteristic(Characteristic.On, false);
       }.bind(this), this.occupancySensor.triggerSwitchToggleTimeout);

--- a/index.js
+++ b/index.js
@@ -540,7 +540,7 @@ class MagicOccupancy {
           }
 
           handleResponse(value);
-      });
+      }.bind(this));
     }
 
     if(switchesToCheck.length == 0 && this._last_occupied_state == true) {

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ module.exports = function (homebridge) {
 class MagicOccupancy {
   constructor(log, config) {
     this.log = log;
-    this.name = config.name || "MagicOccupancy";
+    this.name = config.name.trim() || "MagicOccupancy";
     this.lightSwitchesNames = (config.lightSwitchesNames || "").split(",");
     this.statefulSwitchesNames = (config.statefulSwitchesNames || "").split(",");
     this.triggerSwitchesNames = (config.triggerSwitchesNames || "").split(",");
@@ -564,8 +564,8 @@ class BaseHelperSwitch {
   constructor(occupancySensor, config) {
     this.log = occupancySensor.log;
     this.occupancySensor = occupancySensor;
-    this.name = occupancySensor.name + " " + config.name;
-    this._service = new Service.Switch(this.name, this.name);
+    this.name = occupancySensor.name.trim() + " " + config.name.trim();
+    this._service = new Service.Switch(this.name.trim(), this.name.trim());
 
     this._offDelayTimer = null;
 

--- a/index.js
+++ b/index.js
@@ -412,7 +412,7 @@ class MagicOccupancy {
     this._last_occupied_state = newVal;
     this.occupancyService.setCharacteristic(
       Characteristic.OccupancyDetected,
-      newVal ? Characteristic.OccupationDetected.OCCUPANCY_DETECTED : Characteristic.OccupationDetected.OCCUPANCY_NOT_DETECTED
+      newVal ? Characteristic.OccupancyDetected.OCCUPANCY_DETECTED : Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED
     );
   }
 
@@ -470,7 +470,7 @@ class MagicOccupancy {
    */
   checkOccupancy(timeoutUntilCheck = 0) {
     if(this.locksCounter > 0) {
-      this.log(`checking occupancy waiting for ${this.locksCounter} to clear; waiting for at least 100ms`);
+      this.log.debug(`checking occupancy waiting for ${this.locksCounter} to clear; waiting for at least 100ms`);
       timeoutUntilCheck = Math.max(100, timeoutUntilCheck);
     }
 

--- a/index.js
+++ b/index.js
@@ -177,6 +177,9 @@ class MagicOccupancy {
     if(this.lightSwitchesNames.length > 0) {
       this.log.debug("Making " + this.lightSwitchesNames.length + " Light Switch switchServices");
       this.lightSwitchesNames.forEach(function(switchName) {
+        if(switchName.length == 0) {
+          return true; //continue
+        }
         this.switchServices.push((new LightSwitchMirrorSwitch(this, {
             name: switchName,
             stayOnOnly: false,
@@ -187,6 +190,9 @@ class MagicOccupancy {
     if(this.statefulSwitchesNames.length > 0) {
       this.log.debug("Making " + this.statefulSwitchesNames.length + " Stateful trigger switchServices");
       this.statefulSwitchesNames.forEach(function(switchName) {
+        if(switchName.length == 0) {
+          return true; //continue
+        }
         this.switchServices.push((new StatefulSwitch(this, {
             name: switchName,
             stayOnOnly: false,
@@ -197,6 +203,9 @@ class MagicOccupancy {
     if(this.triggerSwitchesNames.length > 0) {
       this.log.debug("Making " + this.triggerSwitchesNames.length + " Trigger trigger switchServices");
       this.triggerSwitchesNames.forEach(function(switchName) {
+        if(switchName.length == 0) {
+          return true; //continue
+        }
         this.switchServices.push((new TriggerSwitch(this, {
             name: switchName,
             stayOnOnly: false,
@@ -207,6 +216,9 @@ class MagicOccupancy {
     if(this.motionSwitchesNames.length > 0) {
       this.log.debug("Making " + this.motionSwitchesNames.length + " Motion trigger switchServices");
       this.motionSwitchesNames.forEach(function(switchName) {
+        if(switchName.length == 0) {
+          return true; //continue
+        }
         this.switchServices.push((new MotionSensorSwitch(this, {
             name: switchName,
             stayOnOnly: false,
@@ -218,6 +230,9 @@ class MagicOccupancy {
     if(this.statefulStayOnSwitchesNames.length > 0) {
       this.log.debug("Making " + this.statefulStayOnSwitchesNames.length + " StayOn Stateful trigger switchServices");
       this.statefulStayOnSwitchesNames.forEach(function(switchName) {
+        if(switchName.length == 0) {
+          return true; //continue
+        }
         this.switchServices.push((new StatefulSwitch(this, {
             name: switchName,
             stayOnOnly: true,
@@ -228,6 +243,9 @@ class MagicOccupancy {
     if(this.triggerStayOnSwitchesNames.length > 0) {
       this.log.debug("Making " + this.triggerStayOnSwitchesNames.length + " StayOn Trigger trigger switchServices");
       this.triggerStayOnSwitchesNames.forEach(function(switchName) {
+        if(switchName.length == 0) {
+          return true; //continue
+        }
         this.switchServices.push((new TriggerSwitch(this, {
             name: switchName,
             stayOnOnly: true,
@@ -238,6 +256,9 @@ class MagicOccupancy {
     if(this.motionStayOnSwitchesNames.length > 0) {
       this.log.debug("Making " + this.motionStayOnSwitchesNames.length + " StayOn Motion trigger switchServices");
       this.motionStayOnSwitchesNames.forEach(function(switchName) {
+        if(switchName.length == 0) {
+          return true; //continue
+        }
         this.switchServices.push((new MotionSensorSwitch(this, {
             name: switchName,
             stayOnOnly: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta10",
+  "version": "3.0.0-beta11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta1",
+  "version": "3.0.0-beta2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta8",
+  "version": "3.0.0-beta9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "2.4.1",
+  "version": "3.0.0-beta1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta13",
+  "version": "3.0.0-beta14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta7",
+  "version": "3.0.0-beta8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta12",
+  "version": "3.0.0-beta13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta3",
+  "version": "3.0.0-beta4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta5",
+  "version": "3.0.0-beta6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta9",
+  "version": "3.0.0-beta10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta4",
+  "version": "3.0.0-beta5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta14",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta2",
+  "version": "3.0.0-beta3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta6",
+  "version": "3.0.0-beta7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta11",
+  "version": "3.0.0-beta12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta2",
+  "version": "3.0.0-beta3",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta7",
+  "version": "3.0.0-beta8",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta3",
+  "version": "3.0.0-beta4",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta11",
+  "version": "3.0.0-beta12",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta8",
+  "version": "3.0.0-beta9",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta14",
+  "version": "3.0.0",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "2.4.1",
+  "version": "3.0.0-beta1",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta1",
+  "version": "3.0.0-beta2",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta5",
+  "version": "3.0.0-beta6",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta9",
+  "version": "3.0.0-beta10",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta13",
+  "version": "3.0.0-beta14",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta10",
+  "version": "3.0.0-beta11",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta12",
+  "version": "3.0.0-beta13",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta6",
+  "version": "3.0.0-beta7",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-magic-occupancy",
-  "version": "3.0.0-beta4",
+  "version": "3.0.0-beta5",
   "description": "Occupancy sensor linked to several trigger types to allow customizable situations: https://github.com/Jason-Morcos/homebridge-magic-occupancy",
   "main": "index.js",
   "license": "GPL-3.0",


### PR DESCRIPTION
**DO NOT UPDATE TO v3 UNLESS YOU ARE OKAY WITH ALL YOUR PLUGIN CONFIGS BEING RESET TO DEFAULTS WHICH WILL LOSE ANY AUTOMATIONS YOU SET UP IN THE HOME APP. v3 IS A SIGNIFICANT REWRITE AND OFFERS DIFFERENT OPTIONS THAN v2 WHICH ARE VERY POWERFUL BUT REQUIRE A MANUAL UPGRADE**
_Note: You may be able to workaround some of this by entering the names of the switches to perfectly match the previously auto-generated names **before** rebooting Homebridge, but no promises on that one. It's best to assume you will have to set up the plugin again basically from scratch to switch to v3_

- Significant improvements to performance, reliability, and latency
- Better behavior when recovering from a device reboot
- Allow specifying the names of individual sub-switches in the plugin config
- Remote "motion" sensor type in favor of stateful and trigger switches
- Introduce a new "Light Switch" type (see readme for more information)
- Remove the option to treat stateful as trigger if turned on by trigger, use "Light Switch" instead as needed
- Remove max on-time limit of 3600 (now 68+ years is the max limit)