### PR TITLE
Quieter Logging

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -25,6 +25,12 @@
                 "title": "Absolute Max Occupation Time (auto-shutoff)",
                 "type": "number"
             },
+            "occupancyLogging": {
+                "default": true,
+                "description": "Write logs when a sensor becomes occupied or unoccupied.",
+                "title": "Occupancy Logging",
+                "type": "boolean"
+            },
             "persistBetweenReboots": {
                 "default": true,
                 "description": "Whether the occupancy sensor and its switches should restore their previous states on Homebridge restart",

--- a/config.schema.json
+++ b/config.schema.json
@@ -27,7 +27,7 @@
             },
             "occupancyLogging": {
                 "default": true,
-                "description": "Write logs when a sensor becomes occupied or unoccupied.",
+                "description": "Write logs when the occupancy sensor becomes occupied or unoccupied.",
                 "title": "Occupancy Logging",
                 "type": "boolean"
             },

--- a/index.js
+++ b/index.js
@@ -481,15 +481,16 @@ class MagicOccupancy {
     }
 
     _setOccupancyState (newVal) {
-        // Capture previous state and set the new state
+        // Capture the previous state and determine if the state change should be logged
         this.previousModeState = this.modeState;
+        this.occupancyLoggingCondition = (newVal == 'Occupied' && this.previousModeState == 'Unoccupied' || newVal == 'Unoccupied')
+        if (this.occupancyLogging && this.occupancyLoggingCondition) {
+            this.log(`Setting state to ${newVal}`)
+        }
+
+        // Set the new state
         this.modeState = newVal;
         this.log.debug(`Previous state was ${this.previousModeState} and is now ${this.modeState}`)
-
-        // Log when the state changes to Occupied or Unoccupied
-        if (this.modeState == 'Occupied' && this.previousModeState == 'Unoccupied' || this.modeState == 'Unoccupied') {
-            this.occupancyLogging && this.log(`Setting state to ${this.modeState}`)
-        }
 
         this.occupancyService.setCharacteristic(
             Characteristic.OccupancyDetected,

--- a/index.js
+++ b/index.js
@@ -480,7 +480,15 @@ class MagicOccupancy {
     }
 
     _setOccupancyState (newVal) {
+        // Capture previous state and set the new state
+        this.previousModeState = this.modeState;
         this.modeState = newVal;
+        this.log.debug(`Previous state was ${this.previousModeState} and is now ${this.modeState}`)
+
+        // Log when the state changes to Occupied or Unoccupied
+        if (this.modeState == 'Occupied' && this.previousModeState == 'Unoccupied' || this.modeState == 'Unoccupied') {
+            this.log(`Setting state to ${this.modeState}`)
+        }
 
         this.occupancyService.setCharacteristic(
             Characteristic.OccupancyDetected,

--- a/index.js
+++ b/index.js
@@ -483,8 +483,8 @@ class MagicOccupancy {
     _setOccupancyState (newVal) {
         // Capture the previous state and determine if the state change should be logged
         this.previousModeState = this.modeState;
-        this.occupancyLoggingCondition = (newVal == 'Occupied' && this.previousModeState == 'Unoccupied' || newVal == 'Unoccupied')
-        if (this.occupancyLogging && this.occupancyLoggingCondition) {
+        const occupancyLoggingCondition = (newVal == 'Occupied' && this.previousModeState == 'Unoccupied' || newVal == 'Unoccupied')
+        if (this.occupancyLogging && occupancyLoggingCondition) {
             this.log(`Setting state to ${newVal}`)
         }
 

--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ module.exports = function (homebridge) {
 class MagicOccupancy {
     constructor (log, config) {
         this.log = log;
+        this.occupancyLogging = config.occupancyLogging ?? true;
         this.name = config.name.trim() ?? 'MagicOccupancy';
         this.lightSwitchesNames = (config.lightSwitchesNames ?? '').split(',');
         this.statefulSwitchesNames = (config.statefulSwitchesNames ?? '').split(',');
@@ -487,7 +488,7 @@ class MagicOccupancy {
 
         // Log when the state changes to Occupied or Unoccupied
         if (this.modeState == 'Occupied' && this.previousModeState == 'Unoccupied' || this.modeState == 'Unoccupied') {
-            this.log(`Setting state to ${this.modeState}`)
+            this.occupancyLogging && this.log(`Setting state to ${this.modeState}`)
         }
 
         this.occupancyService.setCharacteristic(

--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ class MagicOccupancy {
         this.occupancyService
             .getCharacteristic(Characteristic.TimeoutDelay)
             .on('change', event => {
-                this.log('Setting stay occupied delay to:', event.newValue)
+                this.log.debug('Setting stay occupied delay to:', event.newValue)
                 this.stayOccupiedDelay = event.newValue
             });
 
@@ -177,7 +177,7 @@ class MagicOccupancy {
             .getCharacteristic(Characteristic.TimeRemaining)
             .on('change', event => {
                 if (event.newValue === 0 && event.oldValue > 0) {
-                    this.log('Cancel timer and set occupancy to "NotDetected"')
+                    this.log.debug('Cancel timer and set occupancy to "NotDetected"')
                     this.setOccupancyNotDetected()
                 }
             });
@@ -303,7 +303,7 @@ class MagicOccupancy {
 
         //Handle start on reboot
         if (this.startOnReboot) {
-            this.log(`startOnReboot==true - setting to active`)
+            this.log.debug(`startOnReboot==true - setting to active`)
             //Run the set after homebridge should have booted to ensure events fire
             setTimeout(
                 function () {
@@ -376,7 +376,7 @@ class MagicOccupancy {
         this.stop();
 
         this._timer_started = new Date().getTime();
-        this.log('Timer startUnoccupiedDelayed:', timeRemaining);
+        this.log.debug('Timer startUnoccupiedDelayed:', timeRemaining);
 
         this._timer = setTimeout(
             this.setOccupancyNotDetected.bind(this),
@@ -414,7 +414,7 @@ class MagicOccupancy {
      */
     stop () {
         if (this._timer) {
-            this.log('Delay timer stopped');
+            this.log.debug('Delay timer stopped');
             clearTimeout(this._timer);
             clearInterval(this._interval);
             this._timer = null;
@@ -510,7 +510,7 @@ class MagicOccupancy {
 
         //Clear max timeout
         if (this._max_occupation_timer != null) {
-            this.log('Max occupation timer stopped');
+            this.log.debug('Max occupation timer stopped');
             clearTimeout(this._max_occupation_timer);
             this._max_occupation_timer = null;
         }
@@ -594,7 +594,7 @@ class MagicOccupancy {
                     this.setOccupancyDetected();
                 }
 
-                this.log(
+                this.log.debug(
                     `checkOccupancy result: true. Previous state: ${previousModeState}, current state: ${this.modeState}`
                 );
             }
@@ -606,7 +606,7 @@ class MagicOccupancy {
                     this.startUnoccupiedDelay();
                 }
 
-                this.log(
+                this.log.debug(
                     `checkOccupancy result: false. Previous state: ${previousModeState}, current state: ${this.modeState}`
                 );
             }
@@ -623,7 +623,7 @@ class MagicOccupancy {
                 .getValue(
                     function (err, value) {
                         if (err) {
-                            this.log(
+                            this.log.debug(
                                 `ERROR GETTING VALUE Characteristic.KeepingOccupancyTriggered ${err}`
                             )
                             value = false
@@ -641,7 +641,7 @@ class MagicOccupancy {
         ) {
             this.startUnoccupiedDelay();
 
-            this.log(
+            this.log.debug(
                 `checkOccupancy result: false (0 switches). Previous occupied state: ${previousModeState}, current state: ${this.modeState}`
             );
         }


### PR DESCRIPTION
This pull request makes the following changes and is related to issue #37:

- Move existing logging to debug mode as it is more verbose than what I'd expect to see in the normal Homebridge log. These logs can now be found by enabling Homebridge Debug Mode
- Add logging of state changes that simply show when the state changes to "Occupied" or "Unoccupied"
- Add an option to disable the logging of state changes

Overall, this really cleans up the output to the Homebridge logs while allowing useful state change logging to be captured if desired.